### PR TITLE
Fix OpenGL ClearDepthStencil() mutating masks.

### DIFF
--- a/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
+++ b/src/Veldrid/OpenGL/OpenGLCommandExecutor.cs
@@ -98,28 +98,55 @@ namespace Veldrid.OpenGL
 
         public void ClearDepthStencil(float depth, byte stencil)
         {
-            glClearDepth_Compat(depth);
-            CheckLastError();
+            if (_graphicsPipeline != null)
+            {
+                if (!_graphicsPipeline.DepthStencilState.DepthWriteEnabled)
+                {
+                    glDepthMask(true);
+                    CheckLastError();
+                }
 
-            glStencilMask(~0u);
+                if (_graphicsPipeline.DepthStencilState.StencilWriteMask != 0xFF)
+                {
+                    glStencilMask(0xFF);
+                    CheckLastError();
+                }
+
+                if (_graphicsPipeline.RasterizerState.ScissorTestEnabled)
+                {
+                    glDisable(EnableCap.ScissorTest);
+                    CheckLastError();
+                }
+            }
+
+            glClearDepth_Compat(depth);
             CheckLastError();
 
             glClearStencil(stencil);
             CheckLastError();
 
-            if (_graphicsPipeline != null && _graphicsPipeline.RasterizerState.ScissorTestEnabled)
-            {
-                glDisable(EnableCap.ScissorTest);
-                CheckLastError();
-            }
-
-            glDepthMask(true);
             glClear(ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit);
             CheckLastError();
 
-            if (_graphicsPipeline != null && _graphicsPipeline.RasterizerState.ScissorTestEnabled)
+            if (_graphicsPipeline != null)
             {
-                glEnable(EnableCap.ScissorTest);
+                if (!_graphicsPipeline.DepthStencilState.DepthWriteEnabled)
+                {
+                    glDepthMask(false);
+                    CheckLastError();
+                }
+
+                if (_graphicsPipeline.DepthStencilState.StencilWriteMask != 0xFF)
+                {
+                    glStencilMask(_graphicsPipeline.DepthStencilState.StencilWriteMask);
+                    CheckLastError();
+                }
+
+                if (_graphicsPipeline.RasterizerState.ScissorTestEnabled)
+                {
+                    glEnable(EnableCap.ScissorTest);
+                    CheckLastError();
+                }
             }
         }
 


### PR DESCRIPTION
Commit of ppy.Veldrid: https://github.com/ppy/veldrid/commit/551ba0a8ecc06b57bb9c25445ab391ef5b752697