### PR TITLE
Change D3D to use flip mode

### DIFF
--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -88,7 +88,7 @@ namespace Veldrid.D3D11
                         (int) description.Width, (int) description.Height, _colorFormat),
                     OutputWindow = win32Source.Hwnd,
                     SampleDescription = new SampleDescription(1, 0),
-                    SwapEffect = SwapEffect.Discard,
+                    SwapEffect = SwapEffect.FlipDiscard,
                     BufferUsage = Usage.RenderTargetOutput
                 };
 


### PR DESCRIPTION
Commit of ppy.Veldrid: https://github.com/ppy/veldrid/commit/0351daefbdedda1af15bfa2eb2801d8fcd4f90bc

## Before: `SwapEffect.Discard`

- Old / legacy swap effect (DXGI 1.0 style)
- The back buffer’s contents are undefined after `Present()`
- Uses blt-based presentation (copy from back buffer to the front buffer)
- Higher overhead
- Worse latency
- Poorer integration with the modern Windows compositor (DWM)
- Required for very old Windows versions, but otherwise discouraged

---

## After: `SwapEffect.FlipDiscard`

- Modern flip-model swap effect (DXGI 1.2+)
- The swap chain uses a queue of buffers that are flipped instead of copied
- Back buffer contents are still discarded after present, but:
  - Presentation is much more efficient
  - Lower latency
  - Better performance
  - Better power efficiency
- Required for many modern features:
  - Variable refresh rate (G-Sync / FreeSync)
  - Proper fullscreen optimizations
  - Modern compositor behavior on Windows 10/11
