### PR TITLE
Allow D3D devices to tear if requested

### DIFF
--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -88,7 +88,7 @@ namespace Veldrid.D3D11
                         out device).CheckError();
                 }
             }
-            
+
             ID3D11Device? device;
             try
             {
@@ -215,7 +215,17 @@ namespace Veldrid.D3D11
             lock (_immediateContextLock)
             {
                 D3D11Swapchain d3d11SC = Util.AssertSubtype<Swapchain, D3D11Swapchain>(swapchain);
-                d3d11SC.DxgiSwapChain.Present(d3d11SC.SyncInterval, PresentFlags.None);
+
+                int syncInterval = d3d11SC.SyncInterval;
+                PresentFlags flags = PresentFlags.None;
+
+                if (MainSwapchain != null && ((D3D11Swapchain) MainSwapchain).TearingAllowed && AllowTearing)
+                {
+                    syncInterval = 0;
+                    flags |= PresentFlags.AllowTearing;
+                }
+
+                d3d11SC.DxgiSwapChain.Present(syncInterval, flags);
             }
         }
 

--- a/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
+++ b/src/Veldrid/D3D11/D3D11GraphicsDevice.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Vortice.Direct3D11;
@@ -216,16 +217,15 @@ namespace Veldrid.D3D11
             {
                 D3D11Swapchain d3d11SC = Util.AssertSubtype<Swapchain, D3D11Swapchain>(swapchain);
 
-                int syncInterval = d3d11SC.SyncInterval;
                 PresentFlags flags = PresentFlags.None;
 
-                if (MainSwapchain != null && ((D3D11Swapchain) MainSwapchain).TearingAllowed && AllowTearing)
+                if (MainSwapchain != null && ((D3D11Swapchain) MainSwapchain).TearingAllowed && AllowTearing && !SyncToVerticalBlank)
                 {
-                    syncInterval = 0;
+                    Debug.Assert(d3d11SC.SyncInterval == 0);
                     flags |= PresentFlags.AllowTearing;
                 }
 
-                d3d11SC.DxgiSwapChain.Present(syncInterval, flags);
+                d3d11SC.DxgiSwapChain.Present(d3d11SC.SyncInterval, flags);
             }
         }
 

--- a/src/Veldrid/D3D11/D3D11Swapchain.cs
+++ b/src/Veldrid/D3D11/D3D11Swapchain.cs
@@ -55,14 +55,18 @@ namespace Veldrid.D3D11
 
         public override bool SyncToVerticalBlank
         {
-            get => _vsync; set
+            get => _vsync;
+            set
             {
                 _vsync = value;
                 _syncInterval = D3D11Util.GetSyncInterval(value);
             }
         }
 
+        public bool TearingAllowed => (_flags & SwapChainFlags.AllowTearing) > 0;
+
         private readonly Format _colorFormat;
+        private readonly SwapChainFlags _flags;
 
         public IDXGISwapChain DxgiSwapChain => _dxgiSwapChain;
 
@@ -78,6 +82,12 @@ namespace Veldrid.D3D11
                 ? Format.B8G8R8A8_UNorm_SRgb
                 : Format.B8G8R8A8_UNorm;
 
+            using (IDXGIFactory5 dxgiFactory5 = _gd.Adapter.GetParent<IDXGIFactory5>())
+            {
+                if (dxgiFactory5?.PresentAllowTearing == true)
+                    _flags |= SwapChainFlags.AllowTearing;
+            }
+
             if (description.Source is Win32SwapchainSource win32Source)
             {
                 SwapChainDescription dxgiSCDesc = new()
@@ -89,7 +99,8 @@ namespace Veldrid.D3D11
                     OutputWindow = win32Source.Hwnd,
                     SampleDescription = new SampleDescription(1, 0),
                     SwapEffect = SwapEffect.Discard,
-                    BufferUsage = Usage.RenderTargetOutput
+                    BufferUsage = Usage.RenderTargetOutput,
+                    Flags = _flags
                 };
 
                 using IDXGIFactory dxgiFactory = _gd.Adapter.GetParent<IDXGIFactory>()!;
@@ -111,6 +122,7 @@ namespace Veldrid.D3D11
                     SampleDescription = new SampleDescription(1, 0),
                     SwapEffect = SwapEffect.FlipSequential,
                     BufferUsage = Usage.RenderTargetOutput,
+                    Flags = _flags
                 };
 
                 // Get the Vortice.DXGI factory automatically created when initializing the Direct3D device.
@@ -175,7 +187,7 @@ namespace Veldrid.D3D11
             uint actualHeight = (uint) (height * _pixelScale);
             if (resizeBuffers)
             {
-                _dxgiSwapChain.ResizeBuffers(2, (int) actualWidth, (int) actualHeight, _colorFormat, SwapChainFlags.None).CheckError();
+                _dxgiSwapChain.ResizeBuffers(2, (int) actualWidth, (int) actualHeight, _colorFormat, _flags).CheckError();
             }
 
             // Get the backbuffer from the swapchain

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -118,6 +118,7 @@ namespace Veldrid
 
         /// <summary>
         /// Gets or sets whether the graphics device should allow frames to be displayed as fast as possible even if tearing occurs.
+        /// This will only have an effect if <see cref="SyncToVerticalBlank"/> is false.
         /// </summary>
         public virtual bool AllowTearing { get; set; }
 

--- a/src/Veldrid/GraphicsDevice.cs
+++ b/src/Veldrid/GraphicsDevice.cs
@@ -49,7 +49,7 @@ namespace Veldrid
 
         /// <summary>
         /// Gets a value identifying whether texture coordinates begin in the top left corner of a Texture.
-        /// If true, (0, 0) refers to the top-left texel of a Texture. If false, (0, 0) refers to the bottom-left 
+        /// If true, (0, 0) refers to the top-left texel of a Texture. If false, (0, 0) refers to the bottom-left
         /// texel of a Texture. This property is useful for determining how the output of a Framebuffer should be sampled.
         /// </summary>
         public bool IsUvOriginTopLeft { get; protected set; }
@@ -115,6 +115,11 @@ namespace Veldrid
                 MainSwapchain.SyncToVerticalBlank = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets whether the graphics device should allow frames to be displayed as fast as possible even if tearing occurs.
+        /// </summary>
+        public virtual bool AllowTearing { get; set; }
 
         /// <summary>
         /// The required alignment, in bytes, for uniform buffer offsets. <see cref="DeviceBufferRange.Offset"/> must be a


### PR DESCRIPTION
Commit of ppy.Veldrid: https://github.com/ppy/veldrid/commit/5373ba455068875cf1296f570ea605f4581921d0, https://github.com/ppy/veldrid/commit/d53c6848bb16688734cba39901acd6e85cd404fa

May we could support Vulkan too.

To fix bugs like that:
<img width="1200" height="675" alt="grafik" src="https://github.com/user-attachments/assets/d29404b1-4c24-4494-91b1-2a15fe65b713" />